### PR TITLE
Implementa impressão com pdfmake

### DIFF
--- a/Angular/package.json
+++ b/Angular/package.json
@@ -23,6 +23,7 @@
     "@canvasjs/angular-charts": "^1.2.0",
     "bootstrap": "^5.3.3",
     "ngx-bootstrap": "^12.0.0",
+    "pdfmake": "^0.2.10",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.2"
@@ -33,6 +34,7 @@
     "@angular/compiler-cli": "^17.0.0",
     "@types/jasmine": "~5.1.0",
     "@types/jquery": "^3.5.29",
+    "@types/pdfmake": "^0.2.11",
     "jasmine-core": "~5.1.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/Angular/src/app/pages/cadastros/clientes/clientes.component.html
+++ b/Angular/src/app/pages/cadastros/clientes/clientes.component.html
@@ -5,7 +5,7 @@
         <div class="buttons">
             <small><button (click)="openDialog(Clientes)" class="nav-link"><i class="fa-solid fa-plus"></i>
                     <span>Inserir</span></button></small>
-            <small><button class="nav-link"><i class="fa-solid fa-print"> </i> <span>Listagem</span> </button></small>
+            <small><button (click)="imprimirListagem()" class="nav-link"><i class="fa-solid fa-print"> </i> <span>Listagem</span> </button></small>
         </div>
         <mat-form-field>
             <mat-label><i class="fa-solid fa-magnifying-glass"> </i> Localizar</mat-label>

--- a/Angular/src/app/pages/cadastros/clientes/clientes.component.ts
+++ b/Angular/src/app/pages/cadastros/clientes/clientes.component.ts
@@ -13,6 +13,7 @@ import { MatSortModule } from '@angular/material/sort'
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatDialog } from '@angular/material/dialog'
 import { MatCardModule } from '@angular/material/card';
+import { PrintService } from '../../../services/print.service'
 
 @Component({
   selector: 'app-clientes',
@@ -29,7 +30,7 @@ export class ClientesComponent implements OnInit {
   search:string = ''
   displayedColumns: string[] = ['idCliente', 'nome', 'telefone', 'email', 'doc', 'cep', 'cidade', 'dtCadastro', 'situacao', 'detalhes'];
 
-  constructor(private clientesService: ClientesService, public modal: MatDialog) {}
+  constructor(private clientesService: ClientesService, public modal: MatDialog, private printService: PrintService) {}
 
   ngOnInit(): void {
     this.title = 'CLIENTES'
@@ -47,6 +48,20 @@ export class ClientesComponent implements OnInit {
   applyFilter(event: Event) {
     const filterValue = (event.target as HTMLInputElement).value;
     this.Clientes.filter = filterValue.trim().toLowerCase();
+  }
+
+  imprimirListagem(): void {
+    this.printService.printList<Clientes>('LISTAGEM DE CLIENTES', [
+      { label: '#', field: 'idCliente', width: 35 },
+      { label: 'Nome', field: 'nome', width: '*' },
+      { label: 'Telefone', field: 'telefone', width: 75 },
+      { label: 'E-mail', field: 'email', width: '*' },
+      { label: 'Documento', field: 'doc', width: 80 },
+      { label: 'CEP', field: 'cep', width: 60 },
+      { label: 'Cidade', field: 'cidade', width: 80 },
+      { label: 'Cadastro', field: 'dtCadastro', width: 70 },
+      { label: 'Situação', field: 'situacao', width: 55 }
+    ], this.Clientes.filteredData ?? this.Clientes.data ?? []);
   }
 
   openDialog(cliente: Clientes): void {

--- a/Angular/src/app/pages/cadastros/funcionarios/funcionarios.component.html
+++ b/Angular/src/app/pages/cadastros/funcionarios/funcionarios.component.html
@@ -9,7 +9,7 @@
                     <span>Equipe</span></button></small>
             <small><button (click)="openDialog(Funcionarios)" class="nav-link"><i class="fa-solid fa-plus"></i>
                     <span>Inserir</span></button></small>
-            <small><button class="nav-link"><i class="fa-solid fa-print"> </i> <span>Listagem</span> </button></small>
+            <small><button (click)="imprimirListagem()" class="nav-link"><i class="fa-solid fa-print"> </i> <span>Listagem</span> </button></small>
         </div>
         <mat-form-field>
             <mat-label><i class="fa-solid fa-magnifying-glass"></i> Localizar</mat-label>

--- a/Angular/src/app/pages/cadastros/funcionarios/funcionarios.component.ts
+++ b/Angular/src/app/pages/cadastros/funcionarios/funcionarios.component.ts
@@ -15,6 +15,7 @@ import { MatSortModule } from '@angular/material/sort'
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatDialog } from '@angular/material/dialog'
 import { MatCardModule } from '@angular/material/card';
+import { PrintService } from '../../../services/print.service'
 
 @Component({
   selector: 'app-funcionarios',
@@ -31,7 +32,7 @@ export class FuncionariosComponent implements OnInit {
   search:string = ''
   displayedColumns: string[] = ['idFuncionario', 'nome', 'idUser', 'idEquipe', 'situacao', 'detalhes'];
 
-  constructor(private funcionariosService: FuncionariosService, public modal: MatDialog) {}
+  constructor(private funcionariosService: FuncionariosService, public modal: MatDialog, private printService: PrintService) {}
 
   ngOnInit(): void {
     this.title = 'FUNCIONÁRIOS'
@@ -49,6 +50,16 @@ export class FuncionariosComponent implements OnInit {
   applyFilter(event: Event) {
     const filterValue = (event.target as HTMLInputElement).value;
     this.Funcionarios.filter = filterValue.trim().toLowerCase();
+  }
+
+  imprimirListagem(): void {
+    this.printService.printList<Funcionarios>('LISTAGEM DE FUNCIONÁRIOS', [
+      { label: '#', field: 'idFuncionario', width: 45 },
+      { label: 'Nome', field: 'nome', width: '*' },
+      { label: 'ID Usuário', field: 'idUser', width: 75 },
+      { label: 'ID Equipe', field: 'idEquipe', width: 75 },
+      { label: 'Situação', field: 'situacao', width: 75 }
+    ], this.Funcionarios.filteredData ?? this.Funcionarios.data ?? []);
   }
 
   openDialog(funcionario: Funcionarios): void {

--- a/Angular/src/app/pages/cadastros/servicos/servicos.component.html
+++ b/Angular/src/app/pages/cadastros/servicos/servicos.component.html
@@ -5,7 +5,7 @@
         <div class="buttons">
             <small><button (click)="openDialog(Servicos)" class="nav-link"><i class="fa-solid fa-plus"></i>
                     <span>Inserir</span></button></small>
-            <small><button class="nav-link"><i class="fa-solid fa-print"> </i> <span>Listagem</span> </button></small>
+            <small><button (click)="imprimirListagem()" class="nav-link"><i class="fa-solid fa-print"> </i> <span>Listagem</span> </button></small>
         </div>
         <mat-form-field>
             <mat-label><i class="fa-solid fa-magnifying-glass"></i> Localizar</mat-label>

--- a/Angular/src/app/pages/cadastros/servicos/servicos.component.ts
+++ b/Angular/src/app/pages/cadastros/servicos/servicos.component.ts
@@ -13,6 +13,7 @@ import { MatSortModule } from '@angular/material/sort'
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatDialog } from '@angular/material/dialog'
 import { MatCardModule } from '@angular/material/card';
+import { PrintService } from '../../../services/print.service'
 
 @Component({
   selector: 'app-servicos',
@@ -29,7 +30,7 @@ export class ServicosComponent implements OnInit {
   search:string = ''
   displayedColumns: string[] = ['idServico', 'descricao', 'tipo', 'valor', 'situacao', 'detalhes'];
 
-  constructor(private servicoService: ServicosService, public modal: MatDialog) {}
+  constructor(private servicoService: ServicosService, public modal: MatDialog, private printService: PrintService) {}
 
   ngOnInit(): void {
     this.title = 'SERVIÇOS'
@@ -47,6 +48,16 @@ export class ServicosComponent implements OnInit {
   applyFilter(event: Event) {
     const filterValue = (event.target as HTMLInputElement).value;
     this.Servicos.filter = filterValue.trim().toLowerCase();
+  }
+
+  imprimirListagem(): void {
+    this.printService.printList<Servicos>('LISTAGEM DE SERVIÇOS', [
+      { label: '#', field: 'idServico', width: 45 },
+      { label: 'Descrição', field: 'descricao', width: '*' },
+      { label: 'Tipo', field: 'tipo', width: 70 },
+      { label: 'Valor', field: 'valor', width: 80 },
+      { label: 'Situação', field: 'situacao', width: 70 }
+    ], this.Servicos.filteredData ?? this.Servicos.data ?? []);
   }
 
   openDialog(servico: Servicos): void {

--- a/Angular/src/app/pages/cadastros/veiculos/veiculos.component.html
+++ b/Angular/src/app/pages/cadastros/veiculos/veiculos.component.html
@@ -7,7 +7,7 @@
                     <span>Equipe</span></button></small>
             <small><button (click)="openDialog(Veiculos)" class="nav-link"><i class="fa-solid fa-plus"></i>
                     <span>Inserir</span></button></small>
-            <small><button class="nav-link"><i class="fa-solid fa-print"> </i> <span>Listagem</span> </button></small>
+            <small><button (click)="imprimirListagem()" class="nav-link"><i class="fa-solid fa-print"> </i> <span>Listagem</span> </button></small>
         </div>
         <mat-form-field>
             <mat-label><i class="fa-solid fa-magnifying-glass"></i> Localizar</mat-label>

--- a/Angular/src/app/pages/cadastros/veiculos/veiculos.component.ts
+++ b/Angular/src/app/pages/cadastros/veiculos/veiculos.component.ts
@@ -14,6 +14,7 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatDialog } from '@angular/material/dialog'
 import { MatCardModule } from '@angular/material/card';
 import { EquipesComponent } from '../equipes/equipes.component'
+import { PrintService } from '../../../services/print.service'
 
 @Component({
   selector: 'app-veiculos',
@@ -30,7 +31,7 @@ export class VeiculosComponent implements OnInit {
   search:string = ''
   displayedColumns: string[] = ['idVeiculo', 'modelo', 'marca', 'placa', 'kmRodados', 'idEquipe', 'situacao', 'detalhes'];
 
-  constructor(private veiculosService: VeiculosService, public modal: MatDialog) {}
+  constructor(private veiculosService: VeiculosService, public modal: MatDialog, private printService: PrintService) {}
 
   ngOnInit(): void {
     this.title = 'VEÍCULOS'
@@ -52,6 +53,18 @@ export class VeiculosComponent implements OnInit {
   applyFilter(event: Event) {
     const filterValue = (event.target as HTMLInputElement).value;
     this.Veiculos.filter = filterValue.trim().toLowerCase();
+  }
+
+  imprimirListagem(): void {
+    this.printService.printList<Veiculos>('LISTAGEM DE VEÍCULOS', [
+      { label: '#', field: 'idVeiculo', width: 45 },
+      { label: 'Modelo', field: 'modelo', width: '*' },
+      { label: 'Marca', field: 'marca', width: '*' },
+      { label: 'Placa', field: 'placa', width: 70 },
+      { label: 'KM Rodados', field: 'kmRodados', width: 80 },
+      { label: 'ID Equipe', field: 'idEquipe', width: 70 },
+      { label: 'Situação', field: 'situacao', width: 70 }
+    ], this.Veiculos.filteredData ?? this.Veiculos.data ?? []);
   }
 
   openDialog(veiculo: Veiculos): void {

--- a/Angular/src/app/pages/gestao/gestao.component.html
+++ b/Angular/src/app/pages/gestao/gestao.component.html
@@ -1,1 +1,18 @@
 <app-sub-menu titlePage="{{title}}"></app-sub-menu>
+
+<mat-card class="containerPage">
+    <mat-card-content>
+        <div class="buttons">
+            <small>
+                <button (click)="imprimirOrdemServico()" class="nav-link">
+                    <i class="fa-solid fa-print"></i>
+                    <span>Imprimir OS</span>
+                </button>
+            </small>
+        </div>
+        <p class="m-2">
+            Use o botão acima para imprimir o modelo da Ordem de Serviço. Quando a tela de gestão estiver conectada
+            aos dados reais da OS, passe o objeto da ordem para <strong>imprimirOrdemServico(ordem)</strong>.
+        </p>
+    </mat-card-content>
+</mat-card>

--- a/Angular/src/app/pages/gestao/gestao.component.ts
+++ b/Angular/src/app/pages/gestao/gestao.component.ts
@@ -1,20 +1,52 @@
 import { Component, OnInit } from '@angular/core';
 import { SubMenuComponent } from "../../components/sub-menu/sub-menu.component";
 import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { OrdemServicoPrintData, PrintService } from '../../services/print.service';
 
 @Component({
   selector: 'app-gestao',
   standalone: true,
-  imports: [SubMenuComponent, CommonModule],
+  imports: [SubMenuComponent, CommonModule, MatCardModule],
   templateUrl: './gestao.component.html',
   styleUrl: './gestao.component.css'
 })
 export class GestaoComponent implements OnInit {
   title:string = ''
 
-  constructor() { }
+  constructor(private printService: PrintService) { }
 
   ngOnInit(): void {
     this.title = 'GESTÃO OSERV'
+  }
+
+  imprimirOrdemServico(ordemServico?: OrdemServicoPrintData): void {
+    const dadosImpressao = ordemServico ?? {
+      numero: '0001',
+      dataAbertura: new Date().toLocaleDateString('pt-BR'),
+      previsaoEntrega: '',
+      status: 'Aberta',
+      cliente: 'Cliente não informado',
+      telefone: '',
+      documento: '',
+      endereco: '',
+      veiculo: '',
+      placa: '',
+      km: '',
+      responsavel: '',
+      defeitoRelatado: 'Descreva aqui o problema relatado pelo cliente.',
+      observacao: 'Modelo de impressão. Substitua estes dados pelos dados retornados da API da ordem de serviço.',
+      itens: [
+        {
+          descricao: 'Serviço a executar',
+          quantidade: 1,
+          valorUnitario: 0,
+          valorTotal: 0
+        }
+      ],
+      valorTotal: 0
+    };
+
+    this.printService.printOrdemServico(dadosImpressao);
   }
 }

--- a/Angular/src/app/services/print.service.ts
+++ b/Angular/src/app/services/print.service.ts
@@ -1,0 +1,205 @@
+import { Injectable } from '@angular/core';
+import pdfMake from 'pdfmake/build/pdfmake';
+import pdfFonts from 'pdfmake/build/vfs_fonts';
+import { Content, TDocumentDefinitions } from 'pdfmake/interfaces';
+
+(pdfMake as { vfs?: unknown }).vfs = (pdfFonts as { pdfMake?: { vfs?: unknown }, vfs?: unknown }).pdfMake?.vfs ?? (pdfFonts as { vfs?: unknown }).vfs;
+
+export type PrintColumn<T> = {
+  label: string;
+  field: keyof T | ((row: T) => string | number | boolean | null | undefined);
+  width?: string | number | 'auto' | '*';
+};
+
+export type OrdemServicoPrintItem = {
+  descricao: string;
+  quantidade?: number;
+  valorUnitario?: number;
+  valorTotal?: number;
+};
+
+export type OrdemServicoPrintData = {
+  numero?: string | number;
+  dataAbertura?: string;
+  previsaoEntrega?: string;
+  status?: string;
+  cliente?: string;
+  telefone?: string;
+  documento?: string;
+  endereco?: string;
+  veiculo?: string;
+  placa?: string;
+  km?: string | number;
+  responsavel?: string;
+  defeitoRelatado?: string;
+  observacao?: string;
+  itens?: OrdemServicoPrintItem[];
+  valorTotal?: number;
+};
+
+@Injectable({ providedIn: 'root' })
+export class PrintService {
+  private readonly companyName = 'oServ - Gestão Ordem de Serviço';
+
+  printList<T extends object>(title: string, columns: PrintColumn<T>[], data: T[]): void {
+    const body = [
+      columns.map((column) => ({ text: column.label, style: 'tableHeader' })),
+      ...data.map((row) => columns.map((column) => this.formatValue(this.resolveValue(row, column.field))))
+    ];
+
+    const documentDefinition: TDocumentDefinitions = {
+      pageOrientation: 'landscape',
+      pageMargins: [25, 70, 25, 35],
+      header: this.buildHeader(title),
+      footer: this.buildFooter(),
+      content: [
+        { text: `Total de registros: ${data.length}`, style: 'summary' },
+        {
+          table: {
+            headerRows: 1,
+            widths: columns.map((column) => column.width ?? '*'),
+            body
+          },
+          layout: 'lightHorizontalLines'
+        }
+      ],
+      styles: this.styles()
+    };
+
+    pdfMake.createPdf(documentDefinition).open({}, window.open('', '_blank'));
+  }
+
+  printOrdemServico(data: OrdemServicoPrintData): void {
+    const itens = data.itens?.length ? data.itens : [{ descricao: 'Serviço / Produto', quantidade: 1, valorUnitario: data.valorTotal ?? 0, valorTotal: data.valorTotal ?? 0 }];
+    const total = data.valorTotal ?? itens.reduce((sum, item) => sum + Number(item.valorTotal ?? 0), 0);
+
+    const documentDefinition: TDocumentDefinitions = {
+      pageMargins: [35, 80, 35, 45],
+      header: this.buildHeader(`ORDEM DE SERVIÇO ${data.numero ? `#${data.numero}` : ''}`),
+      footer: this.buildFooter(),
+      content: [
+        this.sectionTitle('Dados da OS'),
+        this.infoTable([
+          ['Número', this.formatValue(data.numero), 'Status', this.formatValue(data.status)],
+          ['Abertura', this.formatValue(data.dataAbertura), 'Previsão', this.formatValue(data.previsaoEntrega)],
+          ['Responsável', this.formatValue(data.responsavel), '', '']
+        ]),
+
+        this.sectionTitle('Cliente'),
+        this.infoTable([
+          ['Nome', this.formatValue(data.cliente), 'Telefone', this.formatValue(data.telefone)],
+          ['Documento', this.formatValue(data.documento), 'Endereço', this.formatValue(data.endereco)]
+        ]),
+
+        this.sectionTitle('Veículo / Equipamento'),
+        this.infoTable([
+          ['Veículo', this.formatValue(data.veiculo), 'Placa', this.formatValue(data.placa)],
+          ['KM', this.formatValue(data.km), '', '']
+        ]),
+
+        this.sectionTitle('Relato / Observações'),
+        { text: data.defeitoRelatado || 'Não informado', margin: [0, 0, 0, 8] },
+        { text: data.observacao || '', margin: [0, 0, 0, 12] },
+
+        this.sectionTitle('Itens da Ordem de Serviço'),
+        {
+          table: {
+            headerRows: 1,
+            widths: ['*', 55, 75, 75],
+            body: [
+              [
+                { text: 'Descrição', style: 'tableHeader' },
+                { text: 'Qtd.', style: 'tableHeader' },
+                { text: 'Vlr. Unit.', style: 'tableHeader' },
+                { text: 'Total', style: 'tableHeader' }
+              ],
+              ...itens.map((item) => [
+                item.descricao,
+                this.formatValue(item.quantidade),
+                this.formatCurrency(item.valorUnitario),
+                this.formatCurrency(item.valorTotal)
+              ])
+            ]
+          },
+          layout: 'lightHorizontalLines'
+        },
+        { text: `Total: ${this.formatCurrency(total)}`, style: 'total' },
+
+        {
+          columns: [
+            { text: '__________________________________\nAssinatura do cliente', alignment: 'center' },
+            { text: '__________________________________\nResponsável técnico', alignment: 'center' }
+          ],
+          margin: [0, 45, 0, 0]
+        }
+      ],
+      styles: this.styles()
+    };
+
+    pdfMake.createPdf(documentDefinition).open({}, window.open('', '_blank'));
+  }
+
+  private buildHeader(title: string) {
+    return () => ({
+      margin: [25, 20, 25, 0],
+      columns: [
+        { text: this.companyName, bold: true, fontSize: 13 },
+        { text: title, alignment: 'right', bold: true, fontSize: 12 }
+      ]
+    });
+  }
+
+  private buildFooter() {
+    return (currentPage: number, pageCount: number) => ({
+      margin: [25, 0, 25, 15],
+      columns: [
+        { text: `Emitido em ${new Date().toLocaleString('pt-BR')}`, fontSize: 8 },
+        { text: `Página ${currentPage} de ${pageCount}`, alignment: 'right', fontSize: 8 }
+      ]
+    });
+  }
+
+  private resolveValue<T>(row: T, field: PrintColumn<T>['field']): unknown {
+    return typeof field === 'function' ? field(row) : row[field];
+  }
+
+  private formatValue(value: unknown): string {
+    if (value === null || value === undefined || value === '') return '-';
+    if (typeof value === 'boolean') return value ? 'Ativo' : 'Suspenso';
+    return String(value);
+  }
+
+  private formatCurrency(value: unknown): string {
+    const numberValue = Number(value ?? 0);
+    return numberValue.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+  }
+
+  private sectionTitle(text: string): Content {
+    return { text, style: 'sectionTitle' };
+  }
+
+  private infoTable(rows: string[][]): Content {
+    return {
+      table: {
+        widths: [80, '*', 80, '*'],
+        body: rows.map((row) => [
+          { text: row[0], bold: true },
+          row[1],
+          { text: row[2], bold: true },
+          row[3]
+        ])
+      },
+      layout: 'lightHorizontalLines',
+      margin: [0, 0, 0, 12]
+    };
+  }
+
+  private styles(): TDocumentDefinitions['styles'] {
+    return {
+      tableHeader: { bold: true, fillColor: '#eeeeee', fontSize: 9 },
+      summary: { margin: [0, 0, 0, 8], fontSize: 9 },
+      sectionTitle: { bold: true, fontSize: 12, margin: [0, 12, 0, 6] },
+      total: { bold: true, alignment: 'right', margin: [0, 10, 0, 0], fontSize: 12 }
+    };
+  }
+}

--- a/Angular/src/types/pdfmake.d.ts
+++ b/Angular/src/types/pdfmake.d.ts
@@ -1,0 +1,23 @@
+declare module 'pdfmake/build/pdfmake' {
+  import type { TDocumentDefinitions } from 'pdfmake/interfaces';
+
+  const pdfMake: {
+    vfs?: unknown;
+    createPdf: (documentDefinitions: TDocumentDefinitions) => {
+      open: (options?: Record<string, unknown>, win?: Window | null) => void;
+      download: (defaultFileName?: string) => void;
+      print: () => void;
+    };
+  };
+
+  export default pdfMake;
+}
+
+declare module 'pdfmake/build/vfs_fonts' {
+  const pdfFonts: {
+    pdfMake?: { vfs?: unknown };
+    vfs?: unknown;
+  };
+
+  export default pdfFonts;
+}


### PR DESCRIPTION
## Resumo
- Adiciona serviço central `PrintService` usando pdfmake.
- Implementa impressão de listagens para Clientes, Funcionários, Veículos e Serviços.
- Adiciona modelo de impressão de Ordem de Serviço na tela de Gestão.
- Adiciona declarações de tipo para imports do pdfmake.
- Inclui `pdfmake` e `@types/pdfmake` no `package.json`.

## Observações
- A impressão de OS foi deixada como modelo funcional porque a tela de gestão ainda não possui dados reais de OS conectados.
- É necessário rodar `npm install` dentro da pasta `Angular` para atualizar o `package-lock.json` localmente e instalar as novas dependências.

## Testes
- Não executei build local neste ambiente.